### PR TITLE
Bump version from 0.1.0 to 0.1.1 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = ["hatchling"]
 [project]
 name = "textutils-dsci524"
 # You can chose to use dynamic versioning with hatch or static where you add it manually.
-version = "0.1.0"
+version = "0.1.1"
 
 description = ""
 authors = [


### PR DESCRIPTION
bumped the version from "0.1.0" to "0.1.1" in pyproject.toml to check if `deploy-test-pypi` workflow is ok publish successful in TestPyPI. 
successful publish: https://test.pypi.org/project/textutils-dsci524/0.1.1/