### PR TITLE
Fix deploy.yml to manual trigger only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,7 @@
 name: deploy-test-pypi
 
 on:
-  push:
-  pull_request:
-    branches: [main]
-  #tags: [ "v*.*.*" ]
-  
-  workflow_dispatch:
+  workflow_dispatch:  # Manual trigger only - use release.yml for tag-based releases
 
 jobs:
   unit-test-pytest:


### PR DESCRIPTION
## Summary
Fix deploy.yml workflow to only run manually (workflow_dispatch).

## Problem
The deploy.yml was triggering on every push, causing duplicate version errors on TestPyPI.

## Solution
Changed trigger from `push` to `workflow_dispatch` only. Tag-based releases now use `release.yml`.